### PR TITLE
fix: 'data integrity check failed' when using additionalData

### DIFF
--- a/src/mechs/aes/crypto.ts
+++ b/src/mechs/aes/crypto.ts
@@ -78,7 +78,7 @@ export class AesCrypto {
       const iv = core.BufferSourceConverter.toUint8Array(algorithm.iv);
       let additionalData;
       if (algorithm.additionalData) {
-        additionalData = core.BufferSourceConverter.toArrayBuffer(algorithm.additionalData);
+        additionalData = core.BufferSourceConverter.toUint8Array(algorithm.additionalData);
       }
       const tagLength = (algorithm.tagLength || 128) / 8;
       result = asmCrypto.AES_GCM[action](data, key.raw, iv, additionalData, tagLength);


### PR DESCRIPTION
Using additionalData throws an error.
Because asmCrypto looks for additionalData.length, but ArrayBuffer doesn't have length property.

```
import * as nodeCrypto from 'crypto';
import * as liner from '../src';

const key = Buffer.from('0123456789abcdef0123456789abcdef');
const iv = Buffer.from('000000000000');
const additionalData = Buffer.from('abcd');
const plainText = Buffer.from('abcd');

const cipher = nodeCrypto.createCipheriv('aes-256-gcm', key, iv);
cipher.setAAD(additionalData);
const cipherTextBuffers = [];
cipherTextBuffers.push(cipher.update(plainText));
cipherTextBuffers.push(cipher.final());
cipherTextBuffers.push(cipher.getAuthTag());
const cipherText = Buffer.concat(cipherTextBuffers);

const linerCrypto = new liner.Crypto();

(async () => {
  const cryptoKey = await linerCrypto.subtle.importKey('raw', key, 'AES-GCM', true, ['encrypt', 'decrypt']);
  const algorithm = {
    name: "AES-GCM",
    iv: iv,
    additionalData: additionalData,
  } as AesGcmParams;
  const enc = await linerCrypto.subtle.decrypt(algorithm, cryptoKey, cipherText);
  console.log(enc);
})();

```