### PR TITLE
Update typing to handle import usage better

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,15 @@
-import * as core from "webcrypto-core"
+import * as core from "webcrypto-core";
 
+export declare const Crypto: new() => core.NativeCrypto;
+export declare const CryptoKey: new() => core.NativeCryptoKey;
 export declare const nativeCrypto: core.NativeCrypto;
 export declare const nativeSubtle: core.NativeSubtleCrypto;
+export declare const crypto: core.NativeCrypto;
 export declare function setCrypto(crypto: core.NativeSubtleCrypto): void;
-export import Crypto = core.NativeCrypto;
-export import CryptoKey = core.NativeCryptoKey;
+
+export type Crypto = core.NativeCrypto;
+export type CryptoKey = core.NativeCryptoKey;
 
 declare global {
-  const liner: {
-    Crypto: new() => core.NativeCrypto;
-    CryptoKey: new () => core.NativeCryptoKey;
-    nativeCrypto: core.NativeCrypto;
-    nativeSubtle: core.NativeSubtleCrypto;
-    setCrypto: (crypto: core.NativeSubtleCrypto) => void;
-    crypto: Crypto;
-  };
+  const liner: typeof import("webcrypto-liner");
 }


### PR DESCRIPTION
Update typing to properly represent what you can import, while keeping the typing and global `liner` exports